### PR TITLE
Build

### DIFF
--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cloud_armor_rules = fileexists(var.cloud_armor.rules_file_path) ? yamldecode(file(var.cloud_armor.rules_file_path)) : []
+  cloud_armor_rules = var.cloud_armor.enabled ? yamldecode(file(var.cloud_armor.rules_file_path)) : []
 }
 
 # Resource configuration for deploying a Google Cloud Run service

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -195,7 +195,7 @@ variable "cloud_armor" {
   })
   default = {
     enabled         = false
-    rules_file_path = ""
+    rules_file_path = "assets/cloud-armor-rules.yaml"
   }
 }
 

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -195,7 +195,7 @@ variable "cloud_armor" {
   })
   default = {
     enabled         = false
-    rules_file_path = "assets/cloud-armor-rules.yaml"
+    rules_file_path = ""
   }
 }
 


### PR DESCRIPTION
Fixes error when cloud armor isn't setup:

```
│ Error: Error in function call
│ 
│   on .terraform/modules/boilerplate.processor_service.processor-service/gcp/cloud-run-v2/main.tf line 2, in locals:
│    2:   cloud_armor_rules = fileexists(var.cloud_armor.rules_file_path) ? yamldecode(file(var.cloud_armor.rules_file_path)) : []
│     ├────────────────
│     │ while calling fileexists(path)
│     │ var.cloud_armor.rules_file_path is ""
│ 
│ Call to function "fileexists" failed: "." is a directory, not a file.
```

https://console.cloud.google.com/cloud-build/builds;region=global/23dbf703-7fd8-4169-b2fa-0d45722aafab;step=3?project=preview-data-ingestor-c0edc062