### PR TITLE
Add liveness probe opts for cloud run v2

### DIFF
--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -29,6 +29,10 @@ resource "google_cloud_run_v2_service" "default" {
 
       # Liveness Probe
       liveness_probe {
+        initial_delay_seconds = var.liveness_probe_initial_delay
+        timeout_seconds       = var.liveness_probe_timeout
+        period_seconds        = var.liveness_probe_period
+        failure_threshold     = var.liveness_probe_failure_threshold
         http_get {
           path = var.liveness_probe_path
         }

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -101,6 +101,7 @@ variable "secrets" {
 
 
 # Corresponding variables for startup probe and liveness probe
+# Startup probe
 variable "startup_probe_initial_delay" {
   description = "Initial delay seconds for the startup probe"
   default     = 0
@@ -126,10 +127,32 @@ variable "startup_probe_port" {
   default     = 8080
 }
 
+# Liveness probe
+variable "liveness_probe_initial_delay" {
+  description = "Initial delay seconds for the liveness probe"
+  default     = 0
+}
+
+variable "liveness_probe_timeout" {
+  description = "Timeout seconds for the liveness probe"
+  default     = 1
+}
+
+variable "liveness_probe_period" {
+  description = "Period seconds for the liveness probe"
+  default     = 3
+}
+
+variable "liveness_probe_failure_threshold" {
+  description = "Failure threshold for the liveness probe"
+  default     = 1
+}
+
 variable "liveness_probe_path" {
   description = "Path for the liveness probe"
   default     = "/"
 }
+
 variable "cpu_limit" {
   description = "CPU limit for the Cloud Run container"
   type        = string

--- a/test/gcp/cloud-run-v2.tf
+++ b/test/gcp/cloud-run-v2.tf
@@ -9,6 +9,10 @@ module "cloud-run-api-my-awesome-api" {
   repository_name     = "my-repo-in-github"
   service_path        = "/services/my-awesome-api"
   dependencies        = ["services/shared/**", "services/types/**"]
+
+  startup_probe_initial_delay = 5
+  liveness_probe_initial_delay = 10
+
   env_vars = {
     "ENVIRONMENT" = "preview"
     "DEBUG"       = "true"


### PR DESCRIPTION
Allow setting initial delay, period, timeout and failure threshold for liveness, much alike startup probe opts.