### PR TITLE
feat(cloud-run): Add enable_custom_domain configuration option

### DIFF
--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -120,6 +120,7 @@ resource "google_cloud_run_service_iam_binding" "noauth" {
 
 # Network Endpoint Group (NEG) for Cloud Run service
 resource "google_compute_region_network_endpoint_group" "cloudrun_neg" {
+  count                 = var.enable_custom_domain ? 1 : 0
   name                  = "${var.name}-neg"
   network_endpoint_type = "SERVERLESS"       # Serverless NEG
   region                = var.project_region # Region
@@ -170,6 +171,7 @@ resource "google_compute_security_policy" "cloud_armor_policy" {
 # Load Balancer module using serverless NEGs
 # View all options on https://github.com/terraform-google-modules/terraform-google-lb-http
 module "lb-http" {
+  count                 = var.enable_custom_domain ? 1 : 0
   source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   project = var.project_id
   name    = "${var.name}-lb"

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -248,3 +248,9 @@ variable "dependencies" {
   type = list(string)
   default = []
 }
+
+variable "enable_custom_domain" {
+  description = "Create necessary resources to bind a custom domain to the resource"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
So that we can disable this for cloud run instances that have an API gateway in front.