### PR TITLE
Add SFTP Server module

### DIFF
--- a/gcp/load-balancer/main.tf
+++ b/gcp/load-balancer/main.tf
@@ -1,0 +1,67 @@
+variable "project" {}
+variable "name" {}
+variable "zone" {}
+variable "port" {}
+variable "google_compute_instance" {}
+variable "ip_address" {}
+
+locals {
+  port_name = "tcp-port-${var.port}"
+}
+
+resource "google_compute_instance_group" "default" {
+  name        = "${var.name}-ig"
+  project     = var.project
+  zone        = var.zone
+  description = "Instance group for port ${var.port}"
+  instances   = [var.google_compute_instance]
+  named_port {
+    name = local.port_name
+    port = var.port
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "${var.name}-health"
+  timeout_sec        = 1
+  check_interval_sec = 10
+  project            = var.project
+  tcp_health_check {
+    port = 80
+  }
+  log_config {
+    enable = true
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name                  = "${var.name}-backend"
+  project               = var.project
+  protocol              = "TCP"
+  port_name             = local.port_name
+  load_balancing_scheme = "EXTERNAL"
+  timeout_sec           = 10
+  health_checks         = [google_compute_health_check.default.id]
+  backend {
+    group           = google_compute_instance_group.default.self_link
+    balancing_mode  = "UTILIZATION"
+    max_utilization = 1.0
+    capacity_scaler = 1.0
+  }
+}
+
+resource "google_compute_target_tcp_proxy" "default" {
+  name            = "${var.name}-proxy"
+  project         = var.project
+  backend_service = google_compute_backend_service.default.id
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  name                  = "${var.name}-fwd"
+  project               = var.project
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = var.port
+  target                = google_compute_target_tcp_proxy.default.id
+  ip_address            = var.ip_address
+}

--- a/gcp/sftp-server/README.md
+++ b/gcp/sftp-server/README.md
@@ -1,0 +1,25 @@
+# SFTP Server with Google Cloud Storage
+
+This Terraform module allows you to create an SFTP server hosted in Google Cloud Platform (GCP) that stores files in a Google Cloud Storage bucket. It sets up the necessary infrastructure, including the VM instance, network, firewall rules, and more. It uses Thorntech's [SFTP Gateway](https://thorntech.com/sftp-gateway-for-google-cloud/).
+
+## Accessing the SFTP Server
+
+You can access the SFTP server using an SFTP client, such as [FileZilla](https://filezilla-project.org/) or the `sftp` command in your terminal. Use the following information:
+
+- Host: The public IP address of the SFTP server (output from Terraform).
+- Port: 22 (default SFTP port).
+- Username: Use the same username as your SSH key.
+- Password: Use your SSH key for authentication.
+
+## Security Considerations
+
+- Ensure that you protect your SSH key and do not share it with unauthorized users.
+- Adjust the firewall rules (`google_compute_firewall`) as needed to control access to your SFTP server.
+
+## Cleaning Up
+
+To destroy the resources created by this Terraform module, run:
+
+```bash
+terraform destroy
+```

--- a/gcp/sftp-server/README.md
+++ b/gcp/sftp-server/README.md
@@ -2,6 +2,14 @@
 
 This Terraform module allows you to create an SFTP server hosted in Google Cloud Platform (GCP) that stores files in a Google Cloud Storage bucket. It sets up the necessary infrastructure, including the VM instance, network, firewall rules, and more. It uses Thorntech's [SFTP Gateway](https://thorntech.com/sftp-gateway-for-google-cloud/).
 
+## Prerequisites
+
+Ensure the following APIs are enabled in your GCP project (the last two might not be necessary as we're managing through terraform, but I haven't tested without):
+
+- `compute.googleapis.com`
+- `deploymentmanager.googleapis.com`
+- `runtimeconfig.googleapis.com`
+
 ## Accessing the SFTP Server
 
 You can access the SFTP server using an SFTP client, such as [FileZilla](https://filezilla-project.org/) or the `sftp` command in your terminal. Use the following information:

--- a/gcp/sftp-server/README.md
+++ b/gcp/sftp-server/README.md
@@ -10,6 +10,10 @@ Ensure the following APIs are enabled in your GCP project (the last two might no
 - `deploymentmanager.googleapis.com`
 - `runtimeconfig.googleapis.com`
 
+## Configuring the SFTP Server
+
+Once provisioned via terraform, the server still needs to be configured with users, linked to the cloud storage bucket, and some other stuff. Go to the IP address generated, create an admin user, and then follow the rest of the setup guide. It's pretty simple.
+
 ## Accessing the SFTP Server
 
 You can access the SFTP server using an SFTP client, such as [FileZilla](https://filezilla-project.org/) or the `sftp` command in your terminal. Use the following information:

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -1,3 +1,7 @@
+locals {
+  tags = ["terraform-instance"]
+}
+
 resource "google_storage_bucket" "bucket" {
   name     = "${var.google_storage_bucket}-${var.project}"
   location = var.region
@@ -9,18 +13,12 @@ resource "google_compute_network" "vpc_network" {
   project = var.project
 }
 
-resource "google_compute_address" "static" {
-  name    = "${var.name}-ip"
-  project = var.project
-  region  = var.region
-}
-
 resource "google_compute_instance" "default" {
   project      = var.project
   name         = var.name
   zone         = var.zone
   machine_type = var.machine_type
-  tags         = ["terraform-instance"]
+  tags         = local.tags
   boot_disk {
     initialize_params {
       image = "thorn-technologies-public/sftpgw-3-4-4-1694633054"
@@ -28,15 +26,156 @@ resource "google_compute_instance" "default" {
   }
   network_interface {
     network = google_compute_network.vpc_network.name
-    access_config {
-      nat_ip = google_compute_address.static.address
-    }
   }
   metadata = {
     ssh-keys = var.ssh-keys
   }
   shielded_instance_config {
     enable_secure_boot = true
+  }
+}
+
+resource "google_compute_instance_group" "http-instance-group" {
+  name        = "${var.name}-http-ig"
+  project     = var.project
+  zone        = var.zone
+  description = "Instance group for HTTP"
+  named_port {
+    name = "tcp-port-80"
+    port = 80
+  }
+}
+
+resource "google_compute_instance_group" "https-instance-group" {
+  name        = "${var.name}-https-ig"
+  project     = var.project
+  zone        = var.zone
+  description = "Instance group for HTTPS"
+  named_port {
+    name = "tcp-port-443"
+    port = 443
+  }
+}
+
+resource "google_compute_instance_group" "ssh-instance-group" {
+  name        = "${var.name}-ssh-ig"
+  project     = var.project
+  zone        = var.zone
+  description = "Instance group for SSH"
+  named_port {
+    name = "tcp-port-22"
+    port = 22
+  }
+}
+
+resource "google_compute_instance_group" "sftp-instance-group" {
+  name        = "${var.name}-sftp-ig"
+  project     = var.project
+  zone        = var.zone
+  description = "Instance group for SFTP"
+  named_port {
+    name = "tcp-port-2222"
+    port = 2222
+  }
+}
+
+module "lb-http" {
+  source      = "GoogleCloudPlatform/lb-http/google"
+  version     = "~> 9.0"
+  project     = var.project
+  name        = "${var.name}-lb"
+  target_tags = local.tags
+  backends = {
+    http = {
+      port        = 80
+      protocol    = "HTTP"
+      port_name   = "tcp-port-80"
+      timeout_sec = 10
+      enable_cdn  = false
+      groups = [
+        {
+          group = google_compute_instance_group.http-instance-group.self_link
+        },
+      ]
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = false
+      }
+      health_check = {
+        port     = 80
+        protocol = "HTTP"
+        path     = "/"
+      }
+    }
+    https = {
+      port        = 443
+      protocol    = "HTTPS"
+      port_name   = "tcp-port-443"
+      timeout_sec = 10
+      enable_cdn  = false
+      groups = [
+        {
+          group = google_compute_instance_group.https-instance-group.self_link
+        },
+      ]
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = false
+      }
+      health_check = {
+        port     = 443
+        protocol = "HTTPS"
+        path     = "/"
+      }
+    }
+    ssh = {
+      port        = 22
+      protocol    = "TCP"
+      port_name   = "tcp-port-22"
+      timeout_sec = 10
+      enable_cdn  = false
+      groups = [
+        {
+          group = google_compute_instance_group.ssh-instance-group.self_link
+        },
+      ]
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = false
+      }
+      health_check = {
+        port     = 22
+        protocol = "TCP"
+      }
+    }
+    sftp = {
+      port        = 2222
+      protocol    = "TCP"
+      port_name   = "tcp-port-2222"
+      timeout_sec = 10
+      enable_cdn  = false
+      groups = [
+        {
+          group = google_compute_instance_group.sftp-instance-group.self_link
+        },
+      ]
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = false
+      }
+      health_check = {
+        port     = 2222
+        protocol = "TCP"
+      }
+    }
   }
 }
 
@@ -48,8 +187,8 @@ resource "google_compute_firewall" "default" {
     protocol = "tcp"
     ports    = ["80", "443", "2222"]
   }
-  target_tags   = ["terraform-instance"]
-  source_ranges = var.source_ranges
+  target_tags   = local.tags
+  source_ranges = compact([module.lb-http.external_ip, module.lb-http.external_ipv6_address])
 }
 
 resource "google_compute_firewall" "sftp-port-22" {
@@ -60,10 +199,6 @@ resource "google_compute_firewall" "sftp-port-22" {
     protocol = "tcp"
     ports    = ["22"]
   }
-  target_tags   = ["terraform-instance"]
-  source_ranges = ["0.0.0.0/0"]
-}
-
-output "public_ip_address" {
-  value = google_compute_address.static.address
+  target_tags   = local.tags
+  source_ranges = compact([module.lb-http.external_ip, module.lb-http.external_ipv6_address])
 }

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -1,0 +1,65 @@
+resource "google_storage_bucket" "bucket" {
+  name     = var.google_storage_bucket
+  location = var.region
+  project  = var.project
+}
+
+resource "google_compute_network" "vpc_network" {
+  name    = "${var.name}-net"
+  project = var.project
+}
+
+resource "google_compute_address" "static" {
+  name    = "${var.name}-ip"
+  project = var.project
+}
+
+resource "google_compute_instance" "default" {
+  project      = var.project
+  name         = var.name
+  zone         = var.zone
+  machine_type = var.machine_type
+  tags         = ["terraform-instance"]
+  boot_disk {
+    initialize_params {
+      image = "thorn-technologies-public/sftpgw-3-4-4-1694633054"
+    }
+  }
+  network_interface {
+    network = google_compute_network.vpc_network.name
+    access_config {
+      nat_ip = google_compute_address.static.address
+    }
+  }
+  metadata = {
+    ssh-keys = var.ssh-keys
+  }
+}
+
+resource "google_compute_firewall" "default" {
+  name    = "${var.name}-fw"
+  project = var.project
+  network = google_compute_network.vpc_network.name
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443", "2222"]
+  }
+  target_tags   = ["terraform-instance"]
+  source_ranges = var.source_ranges
+}
+
+resource "google_compute_firewall" "sftp-port-22" {
+  name    = "${var.name}-sftp-fw"
+  project = var.project
+  network = google_compute_network.vpc_network.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  target_tags   = ["terraform-instance"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "public_ip_address" {
+  value = google_compute_address.static.address
+}

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -1,7 +1,6 @@
 locals {
-  image              = "thorn-technologies-public/sftpgw-3-4-4-1694633054"
-  tags               = ["sftp-instance"]
-  nandos_internal_ip = "203.206.117.131"
+  image = "thorn-technologies-public/sftpgw-3-4-4-1694633054"
+  tags  = ["sftp-instance"]
   # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
   gcp_healthcheck_ip_1 = "130.211.0.0/22"
   gcp_healthcheck_ip_2 = "35.191.0.0/16"
@@ -116,13 +115,15 @@ resource "google_compute_firewall" "default" {
     protocol = "tcp"
     ports    = ["80", "443", "22"]
   }
-  source_ranges = [
-    local.nandos_internal_ip,
-    local.gcp_healthcheck_ip_1,
-    local.gcp_healthcheck_ip_2,
-    local.gcp_iap_ip,
-    google_compute_global_address.default.address,
-  ]
+  source_ranges = concat(
+    var.source_ranges,
+    [
+      local.gcp_healthcheck_ip_1,
+      local.gcp_healthcheck_ip_2,
+      local.gcp_iap_ip,
+      google_compute_global_address.default.address,
+    ]
+  )
 }
 
 resource "google_compute_firewall" "egress" {

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -35,6 +35,9 @@ resource "google_compute_instance" "default" {
   metadata = {
     ssh-keys = var.ssh-keys
   }
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
 }
 
 resource "google_compute_firewall" "default" {

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -96,15 +96,15 @@ module "load-balancer-https" {
 
 # openssh access to the VM
 # but you probably don't need ssh access to the vm
-module "load-balancer-ssh" {
-  source                  = "../load-balancer"
-  project                 = var.project
-  zone                    = var.zone
-  name                    = "${var.name}-ssh"
-  port                    = 2222
-  google_compute_instance = google_compute_instance.default.self_link
-  ip_address              = google_compute_global_address.default.address
-}
+# module "load-balancer-ssh" {
+#   source                  = "../load-balancer"
+#   project                 = var.project
+#   zone                    = var.zone
+#   name                    = "${var.name}-ssh"
+#   port                    = 2222
+#   google_compute_instance = google_compute_instance.default.self_link
+#   ip_address              = google_compute_global_address.default.address
+# }
 
 resource "google_compute_firewall" "default" {
   name        = "${var.name}-fw"
@@ -114,7 +114,7 @@ resource "google_compute_firewall" "default" {
   direction   = "INGRESS"
   allow {
     protocol = "tcp"
-    ports    = ["80", "443", "22", "2222"]
+    ports    = ["80", "443", "22"]
   }
   source_ranges = [
     local.nandos_internal_ip,

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -1,5 +1,5 @@
 resource "google_storage_bucket" "bucket" {
-  name     = var.google_storage_bucket
+  name     = "${var.google_storage_bucket}-${var.project}"
   location = var.region
   project  = var.project
 }
@@ -12,6 +12,7 @@ resource "google_compute_network" "vpc_network" {
 resource "google_compute_address" "static" {
   name    = "${var.name}-ip"
   project = var.project
+  region  = var.region
 }
 
 resource "google_compute_instance" "default" {

--- a/gcp/sftp-server/main.tf
+++ b/gcp/sftp-server/main.tf
@@ -1,5 +1,12 @@
 locals {
-  tags = ["terraform-instance"]
+  image              = "thorn-technologies-public/sftpgw-3-4-4-1694633054"
+  tags               = ["sftp-instance"]
+  nandos_internal_ip = "203.206.117.131"
+  # https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+  gcp_healthcheck_ip_1 = "130.211.0.0/22"
+  gcp_healthcheck_ip_2 = "35.191.0.0/16"
+  # https://cloud.google.com/iap/docs/using-tcp-forwarding
+  gcp_iap_ip = "35.235.240.0/20"
 }
 
 resource "google_storage_bucket" "bucket" {
@@ -13,51 +20,17 @@ resource "google_compute_network" "vpc_network" {
   project = var.project
 }
 
-resource "google_compute_global_address" "default" {
-  name    = "tcp-proxy-xlb-ip"
-  project = var.project
+resource "google_service_account" "default" {
+  project      = var.project
+  account_id   = "sftpuser"
+  display_name = "Custom SA for SFTP VM Instance"
 }
 
-resource "google_compute_target_tcp_proxy" "default" {
-  name            = "${var.name}-proxy"
-  project         = var.project
-  backend_service = google_compute_backend_service.default.id
-}
-
-resource "google_compute_global_forwarding_rule" "default" {
-  name                  = "${var.name}-fwd"
-  project               = var.project
-  ip_protocol           = "TCP"
-  load_balancing_scheme = "EXTERNAL"
-  port_range            = "22"
-  target                = google_compute_target_tcp_proxy.default.id
-  ip_address            = google_compute_global_address.default.id
-}
-
-resource "google_compute_backend_service" "default" {
-  name                  = "tcp-proxy-xlb-backend-service"
-  project               = var.project
-  protocol              = "TCP"
-  port_name             = "tcp-port-22"
-  load_balancing_scheme = "EXTERNAL"
-  timeout_sec           = 10
-  health_checks         = [google_compute_health_check.default.id]
-  backend {
-    group           = google_compute_instance_group.default.self_link
-    balancing_mode  = "UTILIZATION"
-    max_utilization = 1.0
-    capacity_scaler = 1.0
-  }
-}
-
-resource "google_compute_health_check" "default" {
-  name               = "${var.name}-health"
-  timeout_sec        = 1
-  check_interval_sec = 10
-  project            = var.project
-  tcp_health_check {
-    port = "80"
-  }
+resource "google_project_iam_member" "sftpuser" {
+  for_each = toset(["roles/compute.admin", "roles/storage.admin"])
+  project  = var.project
+  member   = google_service_account.default.member
+  role     = each.key
 }
 
 resource "google_compute_instance" "default" {
@@ -68,7 +41,7 @@ resource "google_compute_instance" "default" {
   tags         = local.tags
   boot_disk {
     initialize_params {
-      image = "thorn-technologies-public/sftpgw-3-4-4-1694633054"
+      image = local.image
     }
   }
   network_interface {
@@ -80,52 +53,105 @@ resource "google_compute_instance" "default" {
   shielded_instance_config {
     enable_secure_boot = true
   }
+  service_account {
+    email  = google_service_account.default.email
+    scopes = ["cloud-platform"]
+  }
 }
 
-resource "google_compute_instance_group" "default" {
-  name        = "${var.name}-ig"
-  project     = var.project
-  zone        = var.zone
-  description = "Instance group for all ports"
-  instances   = [google_compute_instance.default.self_link]
-  named_port {
-    name = "tcp-port-22"
-    port = 22
-  }
-  named_port {
-    name = "tcp-port-80"
-    port = 80
-  }
-  named_port {
-    name = "tcp-port-443"
-    port = 443
-  }
-  named_port {
-    name = "tcp-port-2222"
-    port = 2222
-  }
+resource "google_compute_global_address" "default" {
+  name    = "${var.name}-ip"
+  project = var.project
+}
+
+module "load-balancer-sftp" {
+  source                  = "../load-balancer"
+  project                 = var.project
+  zone                    = var.zone
+  name                    = "${var.name}-sftp"
+  port                    = 22
+  google_compute_instance = google_compute_instance.default.self_link
+  ip_address              = google_compute_global_address.default.address
+}
+
+module "load-balancer-http" {
+  source                  = "../load-balancer"
+  project                 = var.project
+  zone                    = var.zone
+  name                    = "${var.name}-http"
+  port                    = 80
+  google_compute_instance = google_compute_instance.default.self_link
+  ip_address              = google_compute_global_address.default.address
+}
+
+module "load-balancer-https" {
+  source                  = "../load-balancer"
+  project                 = var.project
+  zone                    = var.zone
+  name                    = "${var.name}-https"
+  port                    = 443
+  google_compute_instance = google_compute_instance.default.self_link
+  ip_address              = google_compute_global_address.default.address
+}
+
+# openssh access to the VM
+# but you probably don't need ssh access to the vm
+module "load-balancer-ssh" {
+  source                  = "../load-balancer"
+  project                 = var.project
+  zone                    = var.zone
+  name                    = "${var.name}-ssh"
+  port                    = 2222
+  google_compute_instance = google_compute_instance.default.self_link
+  ip_address              = google_compute_global_address.default.address
 }
 
 resource "google_compute_firewall" "default" {
-  name    = "${var.name}-fw"
-  project = var.project
-  network = google_compute_network.vpc_network.name
+  name        = "${var.name}-fw"
+  project     = var.project
+  network     = google_compute_network.vpc_network.name
+  target_tags = local.tags
+  direction   = "INGRESS"
   allow {
     protocol = "tcp"
-    ports    = ["80", "443", "2222"]
+    ports    = ["80", "443", "22", "2222"]
   }
-  target_tags   = local.tags
-  source_ranges = [google_compute_global_address.default.address]
+  source_ranges = [
+    local.nandos_internal_ip,
+    local.gcp_healthcheck_ip_1,
+    local.gcp_healthcheck_ip_2,
+    local.gcp_iap_ip,
+    google_compute_global_address.default.address,
+  ]
 }
 
-resource "google_compute_firewall" "sftp-port-22" {
-  name    = "${var.name}-sftp-fw"
-  project = var.project
-  network = google_compute_network.vpc_network.name
+resource "google_compute_firewall" "egress" {
+  name        = "${var.name}-egress-fw"
+  project     = var.project
+  network     = google_compute_network.vpc_network.name
+  direction   = "EGRESS"
+  priority    = 1000
+  target_tags = local.tags
   allow {
     protocol = "tcp"
-    ports    = ["22"]
+    ports    = ["80", "443"]
   }
-  target_tags   = local.tags
-  source_ranges = [google_compute_global_address.default.address]
+}
+
+# router/NAT to allow egress traffic from sftp server without external IP
+resource "google_compute_router" "default" {
+  project = var.project
+  name    = "${var.name}-router"
+  network = google_compute_network.vpc_network.name
+  region  = var.region
+}
+
+module "cloud-nat" {
+  source                             = "terraform-google-modules/cloud-nat/google"
+  version                            = "~> 5.0"
+  project_id                         = var.project
+  region                             = var.region
+  router                             = google_compute_router.default.name
+  name                               = "${var.name}-nat"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }

--- a/gcp/sftp-server/outputs.tf
+++ b/gcp/sftp-server/outputs.tf
@@ -1,6 +1,3 @@
 output "public_ipv4_address" {
-  value = module.lb-http.external_ip
-}
-output "public_ipv6_address" {
-  value = module.lb-http.external_ipv6_address
+  value = google_compute_global_address.default.address
 }

--- a/gcp/sftp-server/outputs.tf
+++ b/gcp/sftp-server/outputs.tf
@@ -1,0 +1,6 @@
+output "public_ipv4_address" {
+  value = module.lb-http.external_ip
+}
+output "public_ipv6_address" {
+  value = module.lb-http.external_ipv6_address
+}

--- a/gcp/sftp-server/variables.tf
+++ b/gcp/sftp-server/variables.tf
@@ -33,7 +33,7 @@ variable "machine_type" {
 
 variable "ssh-keys" {
   type        = string
-  description = "Key used to SSH into your VM"
+  description = "Key used to SSH into your VM. The format is ubuntu:ssh-rsa AAAAB3NzaC1, where you specify the username followed by the public key."
   default     = null
 }
 

--- a/gcp/sftp-server/variables.tf
+++ b/gcp/sftp-server/variables.tf
@@ -1,0 +1,44 @@
+variable "name" {
+  type        = string
+  description = "Name of the SFTP server"
+}
+
+variable "google_storage_bucket" {
+  type        = string
+  description = "Name of your Google Storage bucket"
+}
+
+variable "project" {
+  type        = string
+  description = "Name of your Google Cloud project"
+}
+
+variable "region" {
+  type        = string
+  description = "Name of your Google Cloud region"
+  default     = "europe-west2"
+}
+
+variable "zone" {
+  type        = string
+  description = "Name of your region zone"
+  default     = "europe-west2-b"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type of your VM"
+  default     = "e2-small"
+}
+
+variable "ssh-keys" {
+  type        = string
+  description = "Key used to SSH into your VM"
+  default     = null
+}
+
+variable "source_ranges" {
+  type        = list(string)
+  description = "Source IP range"
+  default     = []
+}

--- a/gcp/sftp-server/variables.tf
+++ b/gcp/sftp-server/variables.tf
@@ -33,7 +33,7 @@ variable "machine_type" {
 
 variable "ssh-keys" {
   type        = string
-  description = "Key used to SSH into your VM. The format is ubuntu:ssh-rsa AAAAB3NzaC1, where you specify the username followed by the public key."
+  description = "Key used to SSH into your VM. The format is ubuntu:ssh-rsa AAAAB3NzaC1, where you specify the username followed by the public key. If there are multiple SSH keys, each key is separated by a newline character (\\n)."
   default     = null
 }
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,3 +3,4 @@
 *.tfstate.backup
 *.tfstate.*.backup
 .terraform.lock.hcl
+.ssh

--- a/test/gcp/sftp-server.tf
+++ b/test/gcp/sftp-server.tf
@@ -1,0 +1,6 @@
+module "sftp-server" {
+  source                = "../../gcp/sftp-server"
+  project               = "infra-dev-sam-royal-38f6b201"
+  name                  = "test"
+  google_storage_bucket = "sftp"
+}

--- a/test/gcp/sftp-server.tf
+++ b/test/gcp/sftp-server.tf
@@ -4,4 +4,7 @@ module "sftp-server" {
   name                  = "test"
   google_storage_bucket = "sftp"
   ssh-keys              = "testuser:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxuXzhRJCVKOybQVrfEhzW/NnFO96+l7v1RiXatux5gmA7y6DKN2cQt9DjxcGMR+rRqHIgMdwn+ABjPjCi+2YkC8GsdpxFithdTgogvdxjQm+jzKDqNb3RfNAGMwMEP4+VcFFHhZ1uf66cbjiPRE2E601ICaFucTjNYdSaVOq6GyfxKAyYyLCvKfmbSFtNBngT49A0XcG3FccVQpKrovJWXq1Ok31phQiBM/pCxRRjQefeqvGcX/XED+AZCaIEGY1fr7jQZBRc0h5NnTYJoByGP5CVclrUPmBkxXLHzNYatyB8iUyCAXXJ62AQc+EN4mG6A/9/3NdR6WOQSbTqb6kBZbBJjrFwp3vcFVV50TOxfcMpZvYsiQrSiBlEhKnpWk27iSY05FWANbNyTqDh63b+p/RLifYAjCmgRtDnz58XCUKG7q2uI1xvVVW671EWVqGrHP/NfkwwopOtP1NUohQenNAzWIhEA44ONad5cX3qoJN1tpksAHpwp6pZjw3rIjO6k0VPdXvJe2RabCaREhaVlVN4US98Tum+JrNL+OKUAFHumq1xHtNzxvbS1/J/cd6NXKguWWYVh3ir9GDr1YbMnWZgBX4lbIQiF6FiOD82zoDT5WPEsAK2YiDgrvS/g1lVSZnPq4kSVpcwoy3wO5tenHmSUrKMql3PeAjdq7gVrw=="
+  source_ranges = [
+    "203.206.117.131" # nandos network
+  ]
 }

--- a/test/gcp/sftp-server.tf
+++ b/test/gcp/sftp-server.tf
@@ -3,4 +3,5 @@ module "sftp-server" {
   project               = "infra-dev-sam-royal-38f6b201"
   name                  = "test"
   google_storage_bucket = "sftp"
+  ssh-keys              = "testuser:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxuXzhRJCVKOybQVrfEhzW/NnFO96+l7v1RiXatux5gmA7y6DKN2cQt9DjxcGMR+rRqHIgMdwn+ABjPjCi+2YkC8GsdpxFithdTgogvdxjQm+jzKDqNb3RfNAGMwMEP4+VcFFHhZ1uf66cbjiPRE2E601ICaFucTjNYdSaVOq6GyfxKAyYyLCvKfmbSFtNBngT49A0XcG3FccVQpKrovJWXq1Ok31phQiBM/pCxRRjQefeqvGcX/XED+AZCaIEGY1fr7jQZBRc0h5NnTYJoByGP5CVclrUPmBkxXLHzNYatyB8iUyCAXXJ62AQc+EN4mG6A/9/3NdR6WOQSbTqb6kBZbBJjrFwp3vcFVV50TOxfcMpZvYsiQrSiBlEhKnpWk27iSY05FWANbNyTqDh63b+p/RLifYAjCmgRtDnz58XCUKG7q2uI1xvVVW671EWVqGrHP/NfkwwopOtP1NUohQenNAzWIhEA44ONad5cX3qoJN1tpksAHpwp6pZjw3rIjO6k0VPdXvJe2RabCaREhaVlVN4US98Tum+JrNL+OKUAFHumq1xHtNzxvbS1/J/cd6NXKguWWYVh3ir9GDr1YbMnWZgBX4lbIQiF6FiOD82zoDT5WPEsAK2YiDgrvS/g1lVSZnPq4kSVpcwoy3wO5tenHmSUrKMql3PeAjdq7gVrw=="
 }


### PR DESCRIPTION
PoC for spike - https://nandosuk.atlassian.net/browse/SPO-2654

Creates the necessary infrastructure to host an SFTP server in GCP that uses a storage bucket for the file system.

This uses https://console.cloud.google.com/marketplace/vm/config/thorn-technologies-public/sftp-gateway.
Alternatives were https://github.com/drakkan/sftpgo or https://github.com/mikeghen/kubernetes-gcs-sftp but setup seems more complex.

There's a test instance running in my infra-dev project available here, you can login with okta and test around - https://35.227.248.73

In terms of actual usage here, we can either allow each team to create and manage their own server instance using this module, or create a shared instance in a new mgt-sftp project or similar. Upside of a shared instance would be cost saving (each instance runs an e2-small at around £60/m and needs a license for the VM image at $43.80/m) and simplicity, downside is that it's shared infra across multiple teams.

Config seems fairly simple - okta auth was easy and creating users/folders & linking to storage buckets is simple. We could also setup proper SSL (it currently uses a self-signed cert) and a domain name once we have a permanent instance.

There's quite a lot going on for the network setup, in order to not expose the VM to the internet directly, whilst still allowing external traffic to access port 22 for SFTP, and 80/443 for the admin UI. It also needs to allow egress traffic from the VM as the web UI makes some network calls on startup, although this flows through a different shared IP via the cloud router/nat. 