### PR TITLE
feat(data-ingestor-iam): Add module

### DIFF
--- a/gcp/data-ingestor-iam/main.tf
+++ b/gcp/data-ingestor-iam/main.tf
@@ -1,0 +1,13 @@
+locals {
+  data_ingestor_subscriber = {
+    preview = "serviceAccount:terraform@preview-data-ingestor-c0edc062.iam.gserviceaccount.com",
+    preprod = "serviceAccount:terraform@preprod-data-ingestor-6ee5b6e2.iam.gserviceaccount.com",
+    prod    = "serviceAccount:terraform@prod-data-ingestor-40f9b4fb.iam.gserviceaccount.com",
+  }
+}
+
+resource "google_pubsub_topic_iam_member" "data_ingestor_subscriber" {
+  topic  = var.topic
+  role   = "roles/pubsub.subscriber"
+  member = local.data_ingestor_subscriber[var.environment]
+}

--- a/gcp/data-ingestor-iam/variables.tf
+++ b/gcp/data-ingestor-iam/variables.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  type        = string
+  description = "Environment that can be preview, preprod, dev or prod"
+
+  validation {
+    condition     = contains(["preview", "preprod", "prod", "dev"], var.environment)
+    error_message = "The environment must be one of: preview, preprod, dev or prod."
+  }
+}
+
+variable "topic" {
+  type        = string
+  description = "The Pub/Sub topic ID in projects/{{PROJECT_ID}}/topics/{{TOPIC_NAME}} format"
+}


### PR DESCRIPTION
New module to configure IAM policies for the data ingestor, allowing it to subscribe to a Pub/Sub topic for ingestion