### PR TITLE
feat: adds generic event flag for cloud functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/gcp/cloud-function-gen2/main.tf
+++ b/gcp/cloud-function-gen2/main.tf
@@ -29,6 +29,8 @@ locals {
       default_runtime              = "go116"
     }
   }[var.function_type]
+
+  is_generic_event_type = var.event_type != "PUBSUB" && var.event_type != "STORAGE"
 }
 
 /******************************************
@@ -97,7 +99,7 @@ resource "google_cloudfunctions2_function" "function" {
   }
 
   dynamic "event_trigger" {
-    for_each = var.event_trigger != null ? [var.event_trigger] : []
+    for_each = is_generic_event_type ? [var.event_trigger] : []
     content {
       trigger_region        = var.region
       event_type            = event_trigger.value["event_type"]


### PR DESCRIPTION
We were running into an issue where if the user specified that the function should run based off a `STORAGE` trigger, that it would create a second event_trigger leading to errors. 