### PR TITLE
Add optional trigger sa capability

### DIFF
--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -11,6 +11,8 @@ resource "google_cloudbuild_trigger" "trigger_main" {
       invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
     }
   }
+  service_account = var.trigger_service_account
+
   substitutions  = var.substitutions
   filename       = var.filename
   included_files = var.include

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -133,3 +133,9 @@ variable "disabled" {
   default     = false
   description = "Flag to specify if the trigger is disabled."
 }
+
+variable "trigger_service_account" {
+  type        = string
+  description = "Service account to use for the Cloud Build trigger."
+  default     = "None"
+}

--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -11,7 +11,7 @@ locals {
     custom_request_headers  = ["X-Client-Geo-Location: {client_region_subdivision}, {client_city}"]
     custom_response_headers = ["X-Cache-Hit: {cdn_cache_status}"]
     log_config = {
-      enable = var.enable_lb_logging
+      enable      = var.enable_lb_logging
       sample_rate = var.enable_lb_logging ? 1 : 0
     }
     iap_config = {
@@ -331,6 +331,8 @@ module "trigger_provision" {
   include         = concat(["${var.service_path}/**"], var.dependencies)
   exclude         = ["${var.service_path}/functions/**", "${var.service_path}/jobs/**"]
   environment     = var.environment
+
+  trigger_service_account = var.trigger_service_account
 
   # Substitution variables for Cloud Build Trigger
   substitutions = merge({

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -348,3 +348,9 @@ variable "enable_lb_logging" {
   type        = bool
   default     = false
 }
+
+variable "trigger_service_account" {
+  type        = string
+  description = "Service account to use for the Cloud Build trigger."
+  default     = "None"
+}


### PR DESCRIPTION
This PR:
- adds a `service_account` parameter to resolve issues for newly created triggers.
- This parameter is defaulting to `None` to not interfere with existing triggers 