### PR TITLE
bump version to nodejs20

### DIFF
--- a/gcp/cloud-function-gen2/main.tf
+++ b/gcp/cloud-function-gen2/main.tf
@@ -20,7 +20,7 @@ locals {
       source_archive_object_name   = "node-default.zip"
       source_archive_object_source = "../../utils/default-node-function/default.zip"
       default_entry_point          = "helloWorld"
-      default_runtime              = "nodejs16"
+      default_runtime              = "nodejs20"
     }
     go = {
       source_archive_object_name   = "go-default.zip"


### PR DESCRIPTION
nodejs16 -> nodejs20
![Screenshot 2025-02-27 at 11 07 27](https://github.com/user-attachments/assets/e616de42-7586-4310-a784-b73b2f5cc749)
