### PR TITLE
chore : remove roles that are controlled by authoritative policy

### DIFF
--- a/gcp/wiz-security-org/main.tf
+++ b/gcp/wiz-security-org/main.tf
@@ -6,9 +6,6 @@ locals {
 
   fetcher_roles_standard = {
     wiz_security_role               = google_organization_iam_custom_role.wiz_security_role.id
-    viewer                          = "roles/viewer"
-    browser                         = "roles/browser"
-    iam_securityReviewer            = "roles/iam.securityReviewer"
     cloudasset_viewer               = "roles/cloudasset.viewer"
     serviceusage_serviceUsageViewer = "roles/serviceusage.serviceUsageViewer"
   }


### PR DESCRIPTION
### Overview

This PR removes some roles that are controlled via `authoritative` policy in the `nandos dev` organisation. This is to avoid conflicts on which module has management on the listed roles.

Related PR in [here](https://github.com/NandosUK/infrastructure/pull/2309)

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZTNxbWdtYWMzZTdnb29uc3l2cGtjcmltcGFvNGYzMXNmZWNvNzJjNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KFyhUvePRnwcSTmDkI/giphy.gif)
