### PR TITLE
feat: add deletion protection variable to Cloud Run service configuration

### DIFF
--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -22,9 +22,10 @@ locals {
 
 # Resource configuration for deploying a Google Cloud Run service
 resource "google_cloud_run_v2_service" "default" {
-  name     = var.name           # Service name
-  location = var.project_region # Deployment location
-  ingress  = var.ingress
+  name                = var.name           # Service name
+  location            = var.project_region # Deployment location
+  ingress             = var.ingress
+  deletion_protection = var.deletion_protection
 
   template {
     timeout = var.timeout

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -366,3 +366,9 @@ variable "ingress" {
     error_message = "The ingress must be one of: INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
   }
 }
+
+variable "deletion_protection" {
+  description = "Whether Terraform will be prevented from destroying the service. Defaults to true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
By default `deletion_protection` is set to be true in `google_cloud_run_v2_service` resource.

This change surfaces `deletion_protection` as a parameter so terraform configurations using this module can override default behaviour.

Reference: https://registry.terraform.io/providers/hashicorp/google/6.29.0/docs/resources/cloud_run_v2_service#deletion_protection-12