### PR TITLE
feat(cloud-run-v2-job): add service trigger

### DIFF
--- a/gcp/cloud-run-v2-job/main.tf
+++ b/gcp/cloud-run-v2-job/main.tf
@@ -78,6 +78,8 @@ module "trigger_provision" {
   environment     = var.environment
   project_id      = var.project_id
 
+  trigger_service_account = var.trigger_service_account
+
   # Substitution variables for Cloud Build Trigger
   substitutions = merge({
     _STAGE                    = "provision"

--- a/gcp/cloud-run-v2-job/variables.tf
+++ b/gcp/cloud-run-v2-job/variables.tf
@@ -149,9 +149,14 @@ variable "attempt_deadline" {
   default     = "360s"
 }
 
-
 variable "retry_count" {
   description = "The number of times to retry the execution of the job if the previous execution fails."
   type        = number
   default     = 3
+}
+
+variable "trigger_service_account" {
+  description = "The service account to be used for the Cloud Scheduler job to trigger the Cloud Run job."
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
Adds a service account argument to the google_cloud_scheduler_job
resource in the cloud-run-v2-job module. This mirrors the arguments
passed to the cloud-run-v2 module.