### PR TITLE
Add resource type to alert policy module

### DIFF
--- a/gcp/cloud-alerts/main.tf
+++ b/gcp/cloud-alerts/main.tf
@@ -17,7 +17,7 @@ resource "google_monitoring_alert_policy" "error" {
       }
       duration        = "${var.duration}s"
       comparison      = "COMPARISON_GT"
-      filter          = "resource.type = \"cloud_run_revision\" AND resource.labels.service_name = \"${var.service_name}\" AND metric.type = \"logging.googleapis.com/log_entry_count\" AND metric.labels.severity = \"ERROR\""
+      filter          = "resource.type = \"${var.resource_type}\" AND resource.labels.service_name = \"${var.service_name}\" AND metric.type = \"logging.googleapis.com/log_entry_count\" AND metric.labels.severity = \"ERROR\""
       threshold_value = var.threshold_value
 
     }
@@ -28,3 +28,4 @@ resource "google_monitoring_alert_policy" "error" {
 
   notification_channels = var.notification_channels
 }
+

--- a/gcp/cloud-alerts/variables.tf
+++ b/gcp/cloud-alerts/variables.tf
@@ -37,3 +37,9 @@ variable "notification_channels" {
   type        = list(string)
   default     = []
 }
+
+variable "resource_type" {
+  description = "The resource type for the alert filter"
+  type        = string
+  default     = "cloud_run_revision"
+}


### PR DESCRIPTION
The cloud-alerts module is updated to allow a resource type to be passed to it. At present, the resource type is fixed to "cloud_run_revision" which means our Cloud Run Job logs are not being parsed.