### PR TITLE
Fix resource specific filter labels

### DIFF
--- a/gcp/cloud-alerts/main.tf
+++ b/gcp/cloud-alerts/main.tf
@@ -1,3 +1,11 @@
+locals {
+  resource_label = {
+    "cloud_function"     = "function_name"
+    "cloud_run_revision" = "service_name"
+    "cloud_run_job"      = "job_name"
+  }
+}
+
 resource "google_monitoring_alert_policy" "error" {
   display_name = "Error Rate Alert for ${var.service_name}"
   enabled      = var.enabled
@@ -17,9 +25,12 @@ resource "google_monitoring_alert_policy" "error" {
       }
       duration        = "${var.duration}s"
       comparison      = "COMPARISON_GT"
-      filter          = "resource.type = \"${var.resource_type}\" AND resource.labels.service_name = \"${var.service_name}\" AND metric.type = \"logging.googleapis.com/log_entry_count\" AND metric.labels.severity = \"ERROR\""
       threshold_value = var.threshold_value
 
+      filter = "resource.type = \"${var.resource_type}\" \
+        AND resource.labels.${local.resource_label[var.resource_type]} = \"${var.service_name}\" \
+        AND metric.type = \"logging.googleapis.com/log_entry_count\" \
+        AND metric.labels.severity = \"ERROR\""
     }
   }
   alert_strategy {
@@ -28,4 +39,3 @@ resource "google_monitoring_alert_policy" "error" {
 
   notification_channels = var.notification_channels
 }
-

--- a/gcp/cloud-alerts/variables.tf
+++ b/gcp/cloud-alerts/variables.tf
@@ -42,4 +42,9 @@ variable "resource_type" {
   description = "The resource type for the alert filter"
   type        = string
   default     = "cloud_run_revision"
+
+  validation {
+    condition     = contains(["cloud_function", "cloud_run_revision", "cloud_run_job"], var.resource_type)
+    error_message = "Invalid resource_type. Must be one of: cloud_function, cloud_run_revision, cloud_run_job."
+  }
 }

--- a/gcp/cloud-function-gen2/main.tf
+++ b/gcp/cloud-function-gen2/main.tf
@@ -203,4 +203,5 @@ module "cloud_function_alerts" {
   alignment_period      = var.alert_config.alignment_period
   auto_close            = var.alert_config.auto_close
   notification_channels = var.alert_config.notification_channels
+  resource_type         = "cloud_function"
 }


### PR DESCRIPTION
Each resource type has its own specific resource label that must be
specified in the filter. An object is added to map a resource_type to a
resource_label.

Also adds an explicit resource type and label for the Cloud Function
module.