### PR TITLE
feat(cloud-run-v2): enable manual / tag based cloud build trigger invocation

### DIFF
--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -6,12 +6,17 @@ resource "google_cloudbuild_trigger" "trigger_main" {
   tags        = var.tags
   name        = var.name
   location    = var.location
+  
   github {
     owner = var.repository_owner
     name  = var.repository_name
-    push {
-      branch       = var.branching_strategy[var.environment]["provision"]["branch"]
-      invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
+
+    dynamic "push" {
+      for_each = var.trigger_invocation_event == "INVOCATION_EVENT_PUSH" ? [1] : []
+      content {
+        branch       = var.branching_strategy[var.environment]["provision"]["branch"]
+        invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
+      }
     }
   }
   service_account = var.trigger_service_account != "" ? "projects/${data.google_project.current.project_id}/serviceAccounts/${var.trigger_service_account}" : null

--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -12,9 +12,10 @@ resource "google_cloudbuild_trigger" "trigger_main" {
     name  = var.repository_name
 
     dynamic "push" {
-      for_each = var.trigger_invocation_event == "INVOCATION_EVENT_PUSH" ? [1] : []
+      for_each = var.trigger_invocation_event == "INVOCATION_EVENT_PUSH" || var.trigger_invocation_event == "INVOCATION_EVENT_TAG" ? [1] : []
       content {
         branch       = var.branching_strategy[var.environment]["provision"]["branch"]
+        tag          = var.trigger_invocation_event == "INVOCATION_EVENT_TAG" ? var.trigger_invocation_commit_tag : null
         invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
       }
     }

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -119,6 +119,16 @@ variable "branching_strategy" {
   }
 }
 
+variable "trigger_invocation_event" {
+  description = "Invocation event for the trigger"
+  type        = string
+  default     = "INVOCATION_EVENT_PUSH"
+  validation {
+    condition     = contains(["INVOCATION_EVENT_PUSH", "INVOCATION_EVENT_MANUAL"], var.trigger_invocation_event)
+    error_message = "trigger_invocation_event must be one of: INVOCATION_EVENT_PUSH or INVOCATION_EVENT_MANUAL."
+  }
+}
+
 
 # Tags
 variable "tags" {

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -124,11 +124,20 @@ variable "trigger_invocation_event" {
   type        = string
   default     = "INVOCATION_EVENT_PUSH"
   validation {
-    condition     = contains(["INVOCATION_EVENT_PUSH", "INVOCATION_EVENT_MANUAL"], var.trigger_invocation_event)
-    error_message = "trigger_invocation_event must be one of: INVOCATION_EVENT_PUSH or INVOCATION_EVENT_MANUAL."
+    condition     = contains(["INVOCATION_EVENT_PUSH", "INVOCATION_EVENT_TAG", "INVOCATION_EVENT_MANUAL"], var.trigger_invocation_event)
+    error_message = "trigger_invocation_event must be one of: INVOCATION_EVENT_PUSH, INVOCATION_EVENT_TAG or INVOCATION_EVENT_MANUAL."
   }
 }
 
+variable "trigger_invocation_commit_tag" {
+  description = "Optionally used if the trigger is invoked by a commit tag"
+  type        = string
+  default     = null
+  validation {
+    condition     = var.trigger_invocation_event == "INVOCATION_EVENT_TAG" && (var.trigger_invocation_commit_tag == null || can(regex("^[a-zA-Z0-9-_]+$", var.trigger_invocation_commit_tag)))
+    error_message = "var.trigger_invocation_commit_tag must be specified if var.trigger_invocation_event = INVOCATION_EVENT_TAG."
+  }
+}
 
 # Tags
 variable "tags" {

--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -321,19 +321,20 @@ resource "google_project_iam_member" "eventarc_pubsub" {
 
 # Cloud Build trigger configuration
 module "trigger_provision" {
-  count                    = var.create_trigger == true ? 1 : 0
-  source                   = "../cloud-cloudbuild-trigger"
-  trigger_invocation_event = var.trigger_invocation_event
-  name                     = "service-${var.name}-provision"
-  repository_name          = var.repository_name
-  repository_owner         = var.repository_owner
-  location                 = var.location
-  description              = "Provision ${var.name} Service (CI/CD)"
-  filename                 = "${var.service_path}/cloudbuild.yaml"
-  include                  = concat(["${var.service_path}/**"], var.dependencies)
-  exclude                  = ["${var.service_path}/functions/**"]
-  environment              = var.environment
-  project_id               = var.project_id
+  count                         = var.create_trigger == true ? 1 : 0
+  source                        = "../cloud-cloudbuild-trigger"
+  trigger_invocation_event      = var.trigger_invocation_event
+  trigger_invocation_commit_tag = var.trigger_invocation_commit_tag
+  name                          = "service-${var.name}-provision"
+  repository_name               = var.repository_name
+  repository_owner              = var.repository_owner
+  location                      = var.location
+  description                   = "Provision ${var.name} Service (CI/CD)"
+  filename                      = "${var.service_path}/cloudbuild.yaml"
+  include                       = concat(["${var.service_path}/**"], var.dependencies)
+  exclude                       = ["${var.service_path}/functions/**"]
+  environment                   = var.environment
+  project_id                    = var.project_id
 
   trigger_service_account = var.trigger_service_account
 

--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -321,18 +321,19 @@ resource "google_project_iam_member" "eventarc_pubsub" {
 
 # Cloud Build trigger configuration
 module "trigger_provision" {
-  count            = var.create_trigger == true ? 1 : 0
-  source           = "../cloud-cloudbuild-trigger"
-  name             = "service-${var.name}-provision"
-  repository_name  = var.repository_name
-  repository_owner = var.repository_owner
-  location         = var.location
-  description      = "Provision ${var.name} Service (CI/CD)"
-  filename         = "${var.service_path}/cloudbuild.yaml"
-  include          = concat(["${var.service_path}/**"], var.dependencies)
-  exclude          = ["${var.service_path}/functions/**"]
-  environment      = var.environment
-  project_id       = var.project_id
+  count                    = var.create_trigger == true ? 1 : 0
+  source                   = "../cloud-cloudbuild-trigger"
+  trigger_invocation_event = var.trigger_invocation_event
+  name                     = "service-${var.name}-provision"
+  repository_name          = var.repository_name
+  repository_owner         = var.repository_owner
+  location                 = var.location
+  description              = "Provision ${var.name} Service (CI/CD)"
+  filename                 = "${var.service_path}/cloudbuild.yaml"
+  include                  = concat(["${var.service_path}/**"], var.dependencies)
+  exclude                  = ["${var.service_path}/functions/**"]
+  environment              = var.environment
+  project_id               = var.project_id
 
   trigger_service_account = var.trigger_service_account
 

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -118,6 +118,15 @@ variable "trigger_invocation_event" {
   }
 }
 
+variable "trigger_invocation_commit_tag" {
+  description = "Optionally used if the trigger is invoked by a commit tag"
+  type        = string
+  default     = null
+  validation {
+    condition     = var.trigger_invocation_event == "INVOCATION_EVENT_TAG" && (var.trigger_invocation_commit_tag == null || can(regex("^[a-zA-Z0-9-_]+$", var.trigger_invocation_commit_tag)))
+    error_message = "var.trigger_invocation_commit_tag must be specified if var.trigger_invocation_event = INVOCATION_EVENT_TAG."
+  }
+}
 variable "min_scale" {
   description = "Minimum number of instances for autoscaling"
   default     = 1

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -108,6 +108,15 @@ variable "create_trigger" {
   type        = bool
   default     = true
 }
+variable "trigger_invocation_event" {
+  description = "Invocation event for the trigger"
+  type        = string
+  default     = "INVOCATION_EVENT_PUSH"
+  validation {
+    condition     = contains(["INVOCATION_EVENT_PUSH", "INVOCATION_EVENT_MANUAL"], var.trigger_invocation_event)
+    error_message = "trigger_invocation_event must be one of: INVOCATION_EVENT_PUSH or INVOCATION_EVENT_MANUAL."
+  }
+}
 
 variable "min_scale" {
   description = "Minimum number of instances for autoscaling"


### PR DESCRIPTION
# Summary             
                                                                                                                                                                                                                                   
  - Adds a `trigger_invocation_event` variable to the `cloud-cloudbuild-trigger` module that controls whether a trigger fires on push events or should be manually invoked.                                  
    - When set to `INVOCATION_EVENT_MANUAL`, the push block is omitted from the GitHub trigger config, making it only invocable manually
    - Defaults to `INVOCATION_EVENT_PUSH` (existing behaviour) so this is a non-breaking change

  - `cloud-run-v2` module now passes `trigger_invocation_event` → `cloud-cloudbuild-trigger`