### PR TITLE
Allow trigger branching strategy customisation

### DIFF
--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -10,8 +10,8 @@ resource "google_cloudbuild_trigger" "trigger_main" {
     owner = var.repository_owner
     name  = var.repository_name
     push {
-      branch       = var.branching_strategy[var.environment]["provision"]["branch"]
-      invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
+      branch       = local.branching_strategy[var.environment]["provision"]["branch"]
+      invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
     }
   }
   service_account = var.trigger_service_account != "" ? "projects/${data.google_project.current.project_id}/serviceAccounts/${var.trigger_service_account}" : null
@@ -21,4 +21,49 @@ resource "google_cloudbuild_trigger" "trigger_main" {
   included_files = var.include
   ignored_files  = var.exclude
   disabled       = var.disabled
+}
+
+locals {
+  branching_strategy = coalesce(var.branching_strategy, {
+    dev = {
+      validate = {
+        branch       = "^NOT_USED_PREVIEW$"
+        invert_regex = false
+      }
+      provision = {
+        branch       = ".*"
+        invert_regex = false
+      }
+    },
+    preview = {
+      validate = {
+        branch       = "^NOT_USED_PREVIEW$"
+        invert_regex = false
+      }
+      provision = {
+        branch       = ".*"
+        invert_regex = false
+      }
+    },
+    preprod = {
+      validate = {
+        branch       = "^main$|^preprod$|^release/(.*)$"
+        invert_regex = true
+      }
+      provision = {
+        branch       = "^main$|^preprod$|^release/(.*)$"
+        invert_regex = false
+      }
+    },
+    prod = {
+      validate = {
+        branch       = "^main$"
+        invert_regex = true
+      }
+      provision = {
+        branch       = "^main$"
+        invert_regex = false
+      }
+    }
+  })
 }

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -71,54 +71,23 @@ variable "environment" {
   }
 }
 
-
 variable "branching_strategy" {
   description = "Branching strategy for different environments"
-  type        = map(any)
-  default = {
-    dev = {
-      validate = {
-        branch       = "^NOT_USED_PREVIEW$"
-        invert_regex = false
-      }
-      provision = {
-        branch       = ".*"
-        invert_regex = false
-      }
-    },
-    preview = {
-      validate = {
-        branch       = "^NOT_USED_PREVIEW$"
-        invert_regex = false
-      }
-      provision = {
-        branch       = ".*"
-        invert_regex = false
-      }
-    },
-    preprod = {
-      validate = {
-        branch       = "^main$|^preprod$|^release/(.*)$"
-        invert_regex = true
-      }
-      provision = {
-        branch       = "^main$|^preprod$|^release/(.*)$"
-        invert_regex = false
-      }
-    },
-    prod = {
-      validate = {
-        branch       = "^main$"
-        invert_regex = true
-      }
-      provision = {
-        branch       = "^main$"
-        invert_regex = false
-      }
-    }
-  }
-}
 
+  type = map(object({
+    validate = object({
+      branch       = string
+      invert_regex = bool
+    })
+    provision = object({
+      branch       = string
+      invert_regex = bool
+    })
+  }))
+
+  default  = null
+  nullable = true
+}
 
 # Tags
 variable "tags" {

--- a/gcp/cloud-run-v2-job/main.tf
+++ b/gcp/cloud-run-v2-job/main.tf
@@ -66,18 +66,18 @@ resource "google_project_iam_member" "sa_run_invoke" {
 
 # Cloud Build trigger configuration
 module "trigger_provision" {
-  count           = var.create_trigger == true ? 1 : 0
-  source          = "../cloud-cloudbuild-trigger"
-  name            = "service-${var.name}-job-provision"
-  repository_name = var.repository_name
-  location        = var.location
-  description     = "Provision ${var.name} Job (CI/CD)"
-  filename        = "${var.service_path}/cloudbuild.yaml"
-  include         = concat(["${var.service_path}/**"], var.dependencies)
-  exclude         = ["${var.service_path}/functions/**"]
-  environment     = var.environment
-  project_id      = var.project_id
-
+  count                   = var.create_trigger == true ? 1 : 0
+  source                  = "../cloud-cloudbuild-trigger"
+  name                    = "service-${var.name}-job-provision"
+  repository_name         = var.repository_name
+  location                = var.location
+  description             = "Provision ${var.name} Job (CI/CD)"
+  filename                = "${var.service_path}/cloudbuild.yaml"
+  include                 = concat(["${var.service_path}/**"], var.dependencies)
+  exclude                 = ["${var.service_path}/functions/**"]
+  environment             = var.environment
+  project_id              = var.project_id
+  branching_strategy      = var.trigger_branching_strategy
   trigger_service_account = var.trigger_service_account
 
   # Substitution variables for Cloud Build Trigger

--- a/gcp/cloud-run-v2-job/variables.tf
+++ b/gcp/cloud-run-v2-job/variables.tf
@@ -160,3 +160,22 @@ variable "trigger_service_account" {
   type        = string
   default     = ""
 }
+
+variable "trigger_branching_strategy" {
+  description = "Branching strategy for the Cloud Build trigger."
+
+  type = map(object({
+    validate = object({
+      branch       = string
+      invert_regex = bool
+    })
+    provision = object({
+      branch       = string
+      invert_regex = bool
+    })
+  }))
+
+  default  = null
+  nullable = true
+}
+


### PR DESCRIPTION
The Cloud Build trigger is updated to allow parent modules to specify a
custom branching strategy based on a project's needs.

Here the Cloud Run v2 Job is updated to take advantage of this.
Additional modules can be updated in the future to allow for a
customised branching strategy to be passed.

Validation defaults are removed as they're unused in the module.
