### PR TITLE
feat: add in repository connection v2 for cloud run v2

### DIFF
--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -6,12 +6,15 @@ resource "google_cloudbuild_trigger" "trigger_main" {
   tags        = var.tags
   name        = var.name
   location    = var.location
-  github {
-    owner = var.repository_owner
-    name  = var.repository_name
-    push {
-      branch       = var.branching_strategy[var.environment]["provision"]["branch"]
-      invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
+  dynamic "github" {
+    for_each = var.repository == null ? [1] : []
+    content {
+      owner = var.repository_owner
+      name  = var.repository_name
+      push {
+        branch       = var.branching_strategy[var.environment]["provision"]["branch"]
+        invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
+      }
     }
   }
   service_account = var.trigger_service_account != "" ? "projects/${data.google_project.current.project_id}/serviceAccounts/${var.trigger_service_account}" : null

--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -17,6 +17,18 @@ resource "google_cloudbuild_trigger" "trigger_main" {
       }
     }
   }
+
+  dynamic "repository_event_config" {
+    for_each = var.repository != null ? [1] : []
+    content {
+      repository = var.repository
+      push {
+        branch       = var.branching_strategy[var.environment]["provision"]["branch"]
+        invert_regex = var.branching_strategy[var.environment]["provision"]["invert_regex"]
+      }
+    }
+  }
+
   service_account = var.trigger_service_account != "" ? "projects/${data.google_project.current.project_id}/serviceAccounts/${var.trigger_service_account}" : null
 
   substitutions  = var.substitutions

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -42,8 +42,8 @@ variable "repository_owner" {
 
 # Github Repository Name
 variable "repository_name" {
-  type = string
-
+  type        = string
+  default     = null
   description = "The name of the GitHub repository where the service is located"
 }
 

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -144,3 +144,9 @@ variable "project_id" {
   description = "The ID of the project in which the resource belongs."
   type        = string
 }
+
+variable "repository" {
+  type        = string
+  default     = null
+  description = "Full resource ID of a google_cloudbuildv2_repository. If set, uses repository_event_config instead of github block."
+}

--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -332,6 +332,7 @@ module "trigger_provision" {
   exclude          = ["${var.service_path}/functions/**", "${var.service_path}/jobs/**", "${var.service_path}/src/jobs/**"]
   environment      = var.environment
   project_id       = var.project_id
+  repository       = var.repository
 
   trigger_service_account = var.trigger_service_account
 

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -97,6 +97,7 @@ variable "artifact_repository" {
 variable "repository_name" {
   description = "Repo name where the service is located (in GitHub)"
   type        = string
+  default     = null
 }
 variable "repository_owner" {
   description = "Repo owner where the service is located (in GitHub)"

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -366,3 +366,9 @@ variable "ingress" {
     error_message = "The ingress must be one of: INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
   }
 }
+
+variable "repository" {
+  type        = string
+  default     = null
+  description = "Full resource ID of a google_cloudbuildv2_repository. Passed through to the trigger module."
+}

--- a/test/gcp/cloud-run-v2.tf
+++ b/test/gcp/cloud-run-v2.tf
@@ -70,4 +70,3 @@ module "cloud-run-api-my-awesome-api-no-triggers" {
     # ... add more as needed
   }
 }
-

--- a/test/gcp/cloud-run-v2.tf
+++ b/test/gcp/cloud-run-v2.tf
@@ -111,3 +111,37 @@ module "cloud-run-api-example-api-multi-sql" {
     # ... add more as needed
   }
 }
+
+module "cloud-run-api-github-connection-v2" {
+  source              = "../../gcp/cloud-run-v2"
+  project_id          = "mgt-build-56d2ff6b"
+  name                = "my-awesome-api-github-connection-v2"
+  project_region      = "europe-west2"
+  allow_public_access = true
+  create_trigger      = true
+  environment         = "preview"
+  service_path        = "/services/my-awesome-api"
+  repository          = "projects/mgt-build-56d2ff6b/locations/europe-west2/connections/my-connection/repositories/my-repo"
+
+  env_vars = {
+    "ENVIRONMENT" = "preview"
+    "DEBUG"       = "true"
+  }
+}
+
+module "cloud-run-api-github-connection-v1" {
+  source              = "../../gcp/cloud-run-v2"
+  project_id          = "mgt-build-56d2ff6b"
+  name                = "my-awesome-api-github-connection-v1"
+  project_region      = "europe-west2"
+  allow_public_access = true
+  create_trigger      = true
+  environment         = "preview"
+  repository_name     = "my-repo-in-github"
+  service_path        = "/services/my-awesome-api"
+
+  env_vars = {
+    "ENVIRONMENT" = "preview"
+    "DEBUG"       = "true"
+  }
+}


### PR DESCRIPTION
# Description

Cloud Build triggers created with the `github` block rely on legacy 1st-gen GitHub App connections. When deploying to regions where only Developer Connect (v2) connections exist (e.g. `australia-southeast1`, `us-east1`, `europe-north1`, for automating this in RMD), trigger creation fails with: `Error 400: Repository mapping does not exist`

- [RMD PR](https://github.com/NandosUK/rmd/pull/261)
- [RMD Cloud Build logs (for the above issue)](https://console.cloud.google.com/cloud-build/builds;region=europe-west2/d37f1adc-ed31-40f7-8e1d-5e8b252c2562;step=4?project=preview-rmd-5a50974f)

This adds an optional `repository` variable to both `cloud-run-v2` and `cloud-cloudbuild-trigger`. When provided (as a `google_cloudbuildv2_repository` resource ID), the trigger uses `repository_event_config` instead of the `github` block, making it compatible with v2 Developer Connect connections.

# Changes

- `cloud-cloudbuild-trigger`
  - added `repository` variable; `github` and `repository_event_config` blocks are now mutually exclusive dynamic blocks
  - repository_name now defaults to null so callers using the v2 path don't need to pass a dummy value
- `cloud-run-v2`
  - added `repository` variable and passes it through to `trigger_provision`
- `test/gcp/cloud-run-v2.tf`: added two new validation variants — github-connection-v2 (repository set) and github-connection-v1 (repository_name set) — to cover both code paths in CI

# Backwards compatibility

Fully backwards compatible as `repository` defaults to `null`, preserving existing `github` (v1) block behaviour for all callers that don't set it.

`repository_name` in `cloud-cloudbuild-trigger` previously had no default, requiring callers to always provide it. It now defaults to null, which is backwards compatible since it was only used when repository is not set.

# Usage

Pass the ID of an existing `google_cloudbuildv2_repository` resource:

```
module "my-service" {
  source     = "github.com/NandosUK/infrastructure-terraform-modules/gcp/cloud-run-v2"
  repository = google_cloudbuildv2_repository.rmd["australia-southeast1"].id
  ...
}
```