### PR TITLE
feat: add approval_required config to Cloud Build triggers

### DIFF
--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -36,13 +36,9 @@ resource "google_cloudbuild_trigger" "trigger_main" {
   included_files = var.include
   ignored_files  = var.exclude
   disabled       = var.disabled
-
-  dynamic "approval_config" {
-    for_each = var.approval_required ? [1] : []
-    
-    content {
-      approval_required = true
-    }
+  
+  approval_config {
+    approval_required = var.approval_required
   }
 }
 

--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -36,6 +36,14 @@ resource "google_cloudbuild_trigger" "trigger_main" {
   included_files = var.include
   ignored_files  = var.exclude
   disabled       = var.disabled
+
+  dynamic "approval_config" {
+    for_each = var.approval_required ? [1] : []
+    
+    content {
+      approval_required = true
+    }
+  }
 }
 
 locals {

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -119,3 +119,9 @@ variable "repository" {
   default     = null
   description = "Full resource ID of a google_cloudbuildv2_repository. If set, uses repository_event_config instead of github block."
 }
+
+variable "approval_required" {
+  type        = bool
+  default     = false
+  description = "If true, builds will require manual approval before executing."
+}

--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -336,6 +336,7 @@ module "trigger_provision" {
   repository       = var.repository
 
   trigger_service_account = var.trigger_service_account
+  approval_required       = var.approval_required
 
   # Substitution variables for Cloud Build Trigger
   substitutions = merge({

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -395,3 +395,9 @@ variable "repository" {
   default     = null
   description = "Full resource ID of a google_cloudbuildv2_repository. Passed through to the trigger module."
 }
+
+variable "approval_required" {
+  type        = bool
+  default     = false
+  description = "If true, Cloud Build trigger will require manual approval before executing."
+}


### PR DESCRIPTION
https://nandosuk.atlassian.net/browse/SRMD-6983

## Summary

- Add an `approval_required` variable to the `cloud-cloudbuild-trigger` module, which uses a dynamic `approval_config` block to optionally require manual approval before builds execute
- Pass the `approval_required` variable through the `cloud-run-v2` module so consumers can enable approval gating without reaching into the trigger submodule directly
- Defaults to `false` so existing usage is unaffected

## Test plan

- [ ] Verify `terraform plan` with `approval_required = false` (default) produces no diff on existing triggers
- [ ] Verify `terraform plan` with `approval_required = true` adds the `approval_config` block as expected
- [ ] Confirm the variable is correctly forwarded from `cloud-run-v2` to `cloud-cloudbuild-trigger`