### PR TITLE
feat: add approval_required variable to cloud-function-gen2 module

### DIFF
--- a/gcp/cloud-function-gen2/main.tf
+++ b/gcp/cloud-function-gen2/main.tf
@@ -178,6 +178,7 @@ module "trigger_provision" {
   name                    = "function-${var.function_name}-provision"
   description             = "Provision ${var.function_name} Service (CI/CD)"
   source                  = "../cloud-cloudbuild-trigger"
+  approval_required       = var.approval_required
   trigger_service_account = var.trigger_service_account
   location                = var.location
   filename                = var.function_path == "" ? "services/${var.service_name}/functions/${var.function_name}/cloudbuild.yaml" : "${var.function_path}/cloudbuild.yaml"

--- a/gcp/cloud-function-gen2/variables.tf
+++ b/gcp/cloud-function-gen2/variables.tf
@@ -203,3 +203,9 @@ variable "node_version" {
   description = "Default Node.js runtime version for deployed functions"
   default     = "nodejs16"
 }
+
+variable "approval_required" {
+  type        = bool
+  default     = false
+  description = "If true, Cloud Build trigger will require manual approval before executing."
+}


### PR DESCRIPTION
## Summary
- Adds the `approval_required` boolean variable to the `cloud-function-gen2` module, completing the rollout started in #101 for the `cloud-run-v2` and `cloud-cloudbuild-trigger` modules
- Wires the variable through to the Cloud Build trigger resource, allowing consumers to require manual approval before build execution

## Test plan
- [ ] Verify `terraform validate` passes for `cloud-function-gen2`
- [ ] Confirm existing deployments are unaffected (variable defaults to `false`)
- [ ] Test setting `approval_required = true` on a Cloud Function trigger