### PR TITLE
feat: add pull_request trigger type to cloudbuild trigger module

### DIFF
--- a/gcp/cloud-cloudbuild-trigger/main.tf
+++ b/gcp/cloud-cloudbuild-trigger/main.tf
@@ -11,9 +11,21 @@ resource "google_cloudbuild_trigger" "trigger_main" {
     content {
       owner = var.repository_owner
       name  = var.repository_name
-      push {
-        branch       = local.branching_strategy[var.environment]["provision"]["branch"]
-        invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
+
+      dynamic "push" {
+        for_each = var.trigger_type == "push" ? [1] : []
+        content {
+          branch       = local.branching_strategy[var.environment]["provision"]["branch"]
+          invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
+        }
+      }
+      
+      dynamic "pull_request" {
+        for_each = var.trigger_type == "pull_request" ? [1] : []
+        content {
+          branch       = local.branching_strategy[var.environment]["provision"]["branch"]
+          invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
+        }
       }
     }
   }
@@ -22,9 +34,21 @@ resource "google_cloudbuild_trigger" "trigger_main" {
     for_each = var.repository != null ? [1] : []
     content {
       repository = var.repository
-      push {
-        branch       = local.branching_strategy[var.environment]["provision"]["branch"]
-        invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
+
+      dynamic "push" {
+        for_each = var.trigger_type == "push" ? [1] : []
+        content {
+          branch       = local.branching_strategy[var.environment]["provision"]["branch"]
+          invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
+        }
+      }
+      
+      dynamic "pull_request" {
+        for_each = var.trigger_type == "pull_request" ? [1] : []
+        content {
+          branch       = local.branching_strategy[var.environment]["provision"]["branch"]
+          invert_regex = local.branching_strategy[var.environment]["provision"]["invert_regex"]
+        }
       }
     }
   }
@@ -36,7 +60,7 @@ resource "google_cloudbuild_trigger" "trigger_main" {
   included_files = var.include
   ignored_files  = var.exclude
   disabled       = var.disabled
-  
+
   approval_config {
     approval_required = var.approval_required
   }

--- a/gcp/cloud-cloudbuild-trigger/variables.tf
+++ b/gcp/cloud-cloudbuild-trigger/variables.tf
@@ -120,6 +120,17 @@ variable "repository" {
   description = "Full resource ID of a google_cloudbuildv2_repository. If set, uses repository_event_config instead of github block."
 }
 
+variable "trigger_type" {
+  type        = string
+  default     = "push"
+  description = "The repository event that invokes trigger."
+
+  validation {
+    condition     = contains(["push", "pull_request"], var.trigger_type)
+    error_message = "The trigger_type must be either 'push' or 'pull_request'."
+  }
+}
+
 variable "approval_required" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Summary

- Add support for `pull_request` as a trigger event type in the `cloud-cloudbuild-trigger` module, alongside the existing `push` trigger
- Introduce a new `trigger_type` variable (defaulting to `"push"`) with validation, ensuring backwards compatibility
- Convert hardcoded `push` blocks to dynamic blocks in both the `github` and `repository_event_config` configurations

## Test plan

- [ ] Apply an existing configuration that uses the module without setting `trigger_type` and verify it still triggers on push (backwards compatibility)
- [ ] Set `trigger_type = "pull_request"` and verify the trigger is configured for pull request events
- [ ] Confirm that setting an invalid `trigger_type` value fails validation