### PR TITLE
fix(cloud-run-v2): use custom service account for the Cloud Run service, not just the EventArc trigger

### DIFF
--- a/gcp/cloud-run-v2/README.md
+++ b/gcp/cloud-run-v2/README.md
@@ -42,7 +42,8 @@ Key elements description:
 
 ## New Variables
 
-- `var.cloud_run_service_account`: The service account to use for the Cloud Run service.
+- `var.cloud_run_service_account`: The service account used as the Eventarc trigger invoker, and as the Cloud Run service identity when `use_custom_service_account` is `true`.
+- `var.use_custom_service_account`: When `true`, the Cloud Run service runs as `cloud_run_service_account` instead of the default Compute Engine SA. Defaults to `false` to avoid changing existing deployments.
 - `var.sharedVpcConnector`: Shared VPC connection string for internal network access.
 - `var.environment`: The current environment.
 - `var.artifact_repository`: The artifact repository for the service.

--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -28,7 +28,8 @@ resource "google_cloud_run_v2_service" "default" {
   deletion_protection = var.deletion_protection
 
   template {
-    timeout = var.timeout
+    timeout         = var.timeout
+    service_account = var.use_custom_service_account ? var.cloud_run_service_account : null
     containers {
       image = "gcr.io/cloudrun/hello"
 

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -44,6 +44,12 @@ variable "cloud_run_service_account" {
   default     = null
 }
 
+variable "use_custom_service_account" {
+  description = "(Optional) When true, the Cloud Run service will run as cloud_run_service_account instead of the default Compute Engine SA."
+  type        = bool
+  default     = false
+}
+
 variable "allow_public_access" {
   description = "(Optional) Enable/disable public access to the service's original run url."
   type        = bool


### PR DESCRIPTION
Looks like Service Account specified in cloud_run_service_account is not actually used for the Cloud Run.

This PR is to fix this. But to maintain existing behaviour, a flag use_custom_service_account is added. When this flag is set to true, the Cloud Run will run as cloud_run_service_account instead of the default compute SA.