### PR TITLE
Add max_instance_request_conurrency to cloud-run-v2 module

### DIFF
--- a/gcp/cloud-run-v2/main.tf
+++ b/gcp/cloud-run-v2/main.tf
@@ -28,8 +28,9 @@ resource "google_cloud_run_v2_service" "default" {
   deletion_protection = var.deletion_protection
 
   template {
-    timeout         = var.timeout
-    service_account = var.use_custom_service_account ? var.cloud_run_service_account : null
+    timeout                          = var.timeout
+    service_account                  = var.use_custom_service_account ? var.cloud_run_service_account : null
+    max_instance_request_concurrency = var.max_instance_request_concurrency
     containers {
       image = "gcr.io/cloudrun/hello"
 

--- a/gcp/cloud-run-v2/variables.tf
+++ b/gcp/cloud-run-v2/variables.tf
@@ -126,6 +126,12 @@ variable "max_scale" {
   default     = 100
 }
 
+variable "max_instance_request_concurrency" {
+  description = "Maximum number of concurrent requests per instance. Null leaves the Cloud Run default (80)."
+  type        = number
+  default     = null
+}
+
 variable "vpc_access_connector" {
   description = "(Optional) The VPC Access Connector to use for this service"
   type        = string


### PR DESCRIPTION
Adds `max_instance_request_concurrency` variable to `cloud-run-v2` template to allow consumers to control concurrency to a cloud run instance

References
https://docs.cloud.google.com/run/docs/about-concurrency
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service